### PR TITLE
Add Tribute webhook integration

### DIFF
--- a/db/migrations/000005_add_tribute_events.down.sql
+++ b/db/migrations/000005_add_tribute_events.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS tribute_event;

--- a/db/migrations/000005_add_tribute_events.up.sql
+++ b/db/migrations/000005_add_tribute_events.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE tribute_event (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    sent_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    subscription_name TEXT NOT NULL,
+    subscription_id BIGINT NOT NULL,
+    period_id BIGINT NOT NULL,
+    period VARCHAR(20) NOT NULL,
+    price BIGINT NOT NULL,
+    amount BIGINT NOT NULL,
+    currency VARCHAR(10) NOT NULL,
+    user_id BIGINT NOT NULL,
+    telegram_user_id BIGINT NOT NULL,
+    channel_id BIGINT NOT NULL,
+    channel_name TEXT NOT NULL,
+    cancel_reason TEXT,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL
+);

--- a/internal/config/cofig.go
+++ b/internal/config/cofig.go
@@ -45,6 +45,8 @@ type config struct {
 	inboundUUIDs           map[uuid.UUID]uuid.UUID
 	referralDays           int
 	miniApp                string
+	tributeAPIKey          string
+	tributeWebhookAddr     string
 }
 
 var conf config
@@ -67,6 +69,18 @@ func TrialTrafficLimit() int {
 
 func TrialDays() int {
 	return conf.trialDays
+}
+
+func TributeAPIKey() string {
+	return conf.tributeAPIKey
+}
+
+func TributeWebhookAddr() string {
+	return conf.tributeWebhookAddr
+}
+
+func TributeEnabled() bool {
+	return conf.tributeAPIKey != "" && conf.tributeWebhookAddr != ""
 }
 func FeedbackURL() string {
 	return conf.feedbackURL
@@ -392,6 +406,9 @@ func InitConfig() {
 	conf.channelURL = os.Getenv("CHANNEL_URL")
 	conf.tosURL = os.Getenv("TOS_URL")
 
+	conf.tributeAPIKey = os.Getenv("TRIBUTE_API_KEY")
+	conf.tributeWebhookAddr = os.Getenv("TRIBUTE_WEBHOOK_ADDR")
+
 	inboundUUIDsStr := os.Getenv("INBOUND_UUIDS")
 	if inboundUUIDsStr != "" {
 		uuids := strings.Split(inboundUUIDsStr, ",")
@@ -408,5 +425,9 @@ func InitConfig() {
 	} else {
 		conf.inboundUUIDs = map[uuid.UUID]uuid.UUID{}
 		slog.Info("No inbound UUIDs specified, all will be used")
+	}
+
+	if conf.tributeAPIKey == "" || conf.tributeWebhookAddr == "" {
+		slog.Warn("Tribute integration disabled: env vars not set")
 	}
 }

--- a/internal/database/tribute.go
+++ b/internal/database/tribute.go
@@ -1,0 +1,59 @@
+package database
+
+import (
+	"context"
+	sq "github.com/Masterminds/squirrel"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"time"
+)
+
+type TributeEvent struct {
+	ID               int64     `db:"id"`
+	Name             string    `db:"name"`
+	CreatedAt        time.Time `db:"created_at"`
+	SentAt           time.Time `db:"sent_at"`
+	SubscriptionName string    `db:"subscription_name"`
+	SubscriptionID   int64     `db:"subscription_id"`
+	PeriodID         int64     `db:"period_id"`
+	Period           string    `db:"period"`
+	Price            int64     `db:"price"`
+	Amount           int64     `db:"amount"`
+	Currency         string    `db:"currency"`
+	UserID           int64     `db:"user_id"`
+	TelegramUserID   int64     `db:"telegram_user_id"`
+	ChannelID        int64     `db:"channel_id"`
+	ChannelName      string    `db:"channel_name"`
+	CancelReason     *string   `db:"cancel_reason"`
+	ExpiresAt        time.Time `db:"expires_at"`
+}
+
+type TributeRepository struct {
+	pool *pgxpool.Pool
+}
+
+func NewTributeRepository(pool *pgxpool.Pool) *TributeRepository {
+	return &TributeRepository{pool: pool}
+}
+
+func (r *TributeRepository) Insert(ctx context.Context, ev *TributeEvent) error {
+	builder := sq.Insert("tribute_event").
+		Columns(
+			"name", "created_at", "sent_at", "subscription_name", "subscription_id",
+			"period_id", "period", "price", "amount", "currency", "user_id",
+			"telegram_user_id", "channel_id", "channel_name", "cancel_reason", "expires_at",
+		).
+		Values(
+			ev.Name, ev.CreatedAt, ev.SentAt, ev.SubscriptionName, ev.SubscriptionID,
+			ev.PeriodID, ev.Period, ev.Price, ev.Amount, ev.Currency, ev.UserID,
+			ev.TelegramUserID, ev.ChannelID, ev.ChannelName, ev.CancelReason, ev.ExpiresAt,
+		).
+		PlaceholderFormat(sq.Dollar)
+
+	sql, args, err := builder.ToSql()
+	if err != nil {
+		return err
+	}
+
+	_, err = r.pool.Exec(ctx, sql, args...)
+	return err
+}

--- a/internal/tribute/server.go
+++ b/internal/tribute/server.go
@@ -1,0 +1,174 @@
+package tribute
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+	"remnawave-tg-shop-bot/internal/config"
+	"remnawave-tg-shop-bot/internal/database"
+	"remnawave-tg-shop-bot/internal/remnawave"
+	"remnawave-tg-shop-bot/internal/translation"
+)
+
+// WebhookEvent represents incoming Tribute webhook payload
+type WebhookEvent struct {
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+	SentAt    time.Time `json:"sent_at"`
+	Payload   struct {
+		SubscriptionName string    `json:"subscription_name"`
+		SubscriptionID   int64     `json:"subscription_id"`
+		PeriodID         int64     `json:"period_id"`
+		Period           string    `json:"period"`
+		Price            int64     `json:"price"`
+		Amount           int64     `json:"amount"`
+		Currency         string    `json:"currency"`
+		UserID           int64     `json:"user_id"`
+		TelegramUserID   int64     `json:"telegram_user_id"`
+		ChannelID        int64     `json:"channel_id"`
+		ChannelName      string    `json:"channel_name"`
+		CancelReason     string    `json:"cancel_reason"`
+		ExpiresAt        time.Time `json:"expires_at"`
+	} `json:"payload"`
+}
+
+// Server handles Tribute webhooks
+type Server struct {
+	repo         *database.TributeRepository
+	customerRepo *database.CustomerRepository
+	remClient    *remnawave.Client
+	tm           *translation.Manager
+	bot          *bot.Bot
+}
+
+func NewServer(repo *database.TributeRepository, customerRepo *database.CustomerRepository, remClient *remnawave.Client, tm *translation.Manager, b *bot.Bot) *Server {
+	return &Server{repo: repo, customerRepo: customerRepo, remClient: remClient, tm: tm, bot: b}
+}
+
+func verifySignature(body []byte, signature string) bool {
+	mac := hmac.New(sha256.New, []byte(config.TributeAPIKey()))
+	mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(expected), []byte(signature))
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	if !verifySignature(body, r.Header.Get("trbt-signature")) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var event WebhookEvent
+	if err := json.Unmarshal(body, &event); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	dbEvent := &database.TributeEvent{
+		Name:             event.Name,
+		CreatedAt:        event.CreatedAt,
+		SentAt:           event.SentAt,
+		SubscriptionName: event.Payload.SubscriptionName,
+		SubscriptionID:   event.Payload.SubscriptionID,
+		PeriodID:         event.Payload.PeriodID,
+		Period:           event.Payload.Period,
+		Price:            event.Payload.Price,
+		Amount:           event.Payload.Amount,
+		Currency:         event.Payload.Currency,
+		UserID:           event.Payload.UserID,
+		TelegramUserID:   event.Payload.TelegramUserID,
+		ChannelID:        event.Payload.ChannelID,
+		ChannelName:      event.Payload.ChannelName,
+		ExpiresAt:        event.Payload.ExpiresAt,
+	}
+	if event.Payload.CancelReason != "" {
+		dbEvent.CancelReason = &event.Payload.CancelReason
+	}
+
+	if err := s.repo.Insert(r.Context(), dbEvent); err != nil {
+		slog.Error("failed to save tribute event", "error", err)
+	}
+
+	switch event.Name {
+	case "new_subscription":
+		s.handleNewSubscription(r.Context(), &event)
+	case "cancelled_subscription":
+		s.handleCancelledSubscription(r.Context(), &event)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"ok":true}`))
+}
+
+func (s *Server) handleNewSubscription(ctx context.Context, ev *WebhookEvent) {
+	customer, err := s.customerRepo.FindByTelegramId(ctx, ev.Payload.TelegramUserID)
+	if err != nil {
+		slog.Error("find customer", "err", err)
+		return
+	}
+	if customer == nil {
+		customer, err = s.customerRepo.Create(ctx, &database.Customer{TelegramID: ev.Payload.TelegramUserID, Language: "en"})
+		if err != nil {
+			slog.Error("create customer", "err", err)
+			return
+		}
+	}
+
+	user, err := s.remClient.UpdateExpireAt(ctx, customer.ID, customer.TelegramID, ev.Payload.ExpiresAt)
+	if err != nil {
+		slog.Error("update remnawave user", "err", err)
+		return
+	}
+
+	updates := map[string]interface{}{
+		"subscription_link": user.SubscriptionUrl,
+		"expire_at":         user.ExpireAt,
+	}
+	if err := s.customerRepo.UpdateFields(ctx, customer.ID, updates); err != nil {
+		slog.Error("update customer", "err", err)
+	}
+
+	_, err = s.bot.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID: customer.TelegramID,
+		Text:   s.tm.GetText(customer.Language, "subscription_activated"),
+		ReplyMarkup: models.InlineKeyboardMarkup{
+			InlineKeyboard: [][]models.InlineKeyboardButton{
+				{
+					{Text: s.tm.GetText(customer.Language, "connect_button"), CallbackData: "connect"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		slog.Error("send message", "err", err)
+	}
+}
+
+func (s *Server) handleCancelledSubscription(ctx context.Context, ev *WebhookEvent) {
+	customer, err := s.customerRepo.FindByTelegramId(ctx, ev.Payload.TelegramUserID)
+	if err != nil || customer == nil {
+		return
+	}
+	updates := map[string]interface{}{
+		"expire_at": ev.Payload.ExpiresAt,
+	}
+	if err := s.customerRepo.UpdateFields(ctx, customer.ID, updates); err != nil {
+		slog.Error("update customer", "err", err)
+	}
+	s.remClient.UpdateExpireAt(ctx, customer.ID, customer.TelegramID, ev.Payload.ExpiresAt)
+}

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,8 @@ The application requires the following environment variables to be set:
 | `TRIAL_TRAFFIC_LIMIT`    | Maximum allowed traffic in gb for trial subscriptions                                                                                        |     
 | `TRIAL_DAYS`             | Number of days for trial subscriptions. if 0 = disabled.                                                                                     |
 | `INBOUND_UUIDS`          | Comma-separated list of inbound UUIDs to assign to users (e.g., "773db654-a8b2-413a-a50b-75c3536238fd,bc979bdd-f1fa-4d94-8a51-38a0f518a2a2") |
+| `TRIBUTE_API_KEY`        | API key for Tribute webhook signature verification |
+| `TRIBUTE_WEBHOOK_ADDR`   | Address for Tribute webhook server (e.g., ":8080") |
 
 ## User Interface
 
@@ -129,6 +131,9 @@ mv .env.sample .env
    ```bash
    docker compose up -d
    ```
+
+4. In the Tribute dashboard generate an API key and set the webhook URL to `http://<your-server-address>/` combined with the value of `TRIBUTE_WEBHOOK_ADDR`.
+   The bot will automatically validate requests using the key from `TRIBUTE_API_KEY`.
 
 ## How to change bot messages
 


### PR DESCRIPTION
## Summary
- create Tribute events table and repository
- add Tribute webhook server with signature verification
- update Remnawave client to set user expiration
- launch Tribute webhook server in main app
- expose Tribute config values and document them

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862b2e853748321a488ced4f6c61840